### PR TITLE
Update sendMessageCompletion to handle BLEManagerError with human-readable message

### DIFF
--- a/Sources/SwiftOBD2/Communication/bleManager.swift
+++ b/Sources/SwiftOBD2/Communication/bleManager.swift
@@ -299,7 +299,12 @@ class BLEManager: NSObject, CommProtocol {
                     if let response = response {
                         continuation.resume(returning: response)
                     } else if let error = error {
-                        continuation.resume(throwing: error)
+                        if let bleError = error as? BLEManagerError {
+                            // Handle the BLEManagerError cases
+                            continuation.resume(returning: [bleError.description])
+                        } else {
+                            continuation.resume(throwing: error)
+                        }
                     }
                     self.sendMessageCompletion = nil
                 }


### PR DESCRIPTION
Update sendMessageCompletion to handle BLEManagerError.noData case with human-readable message
- For example current method returns: "The operation couldn’t be completed. (SwiftOBD2.BLEManagerError error 5.)" for "No DATA" whilst running "DTC". It's not user friendly.