### PR TITLE
Feature/handle ble manager error cases

### DIFF
--- a/Sources/SwiftOBD2/Communication/bleManager.swift
+++ b/Sources/SwiftOBD2/Communication/bleManager.swift
@@ -142,7 +142,12 @@ class BLEManager: NSObject, CommProtocol {
                     if let peripheral = peripheral {
                         continuation.resume(returning: peripheral)
                     } else if let error = error {
-                        continuation.resume(throwing: error)
+                        if let bleError = error as? BLEManagerError {
+                            // Handle the BLEManagerError cases
+                            continuation.resume(returning: [bleError.description])
+                        } else {
+                            continuation.resume(throwing: error)
+                        }
                     }
                     self.foundPeripheralCompletion = nil
                 }
@@ -260,7 +265,12 @@ class BLEManager: NSObject, CommProtocol {
                 if let _ = peripheral {
                     continuation.resume()
                 } else if let error = error {
-                    continuation.resume(throwing: error)
+                    if let bleError = error as? BLEManagerError {
+                        // Handle the BLEManagerError cases
+                        continuation.resume(returning: [bleError.description])
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
             connect(to: peripheral)

--- a/Sources/SwiftOBD2/Communication/bleManager.swift
+++ b/Sources/SwiftOBD2/Communication/bleManager.swift
@@ -142,12 +142,7 @@ class BLEManager: NSObject, CommProtocol {
                     if let peripheral = peripheral {
                         continuation.resume(returning: peripheral)
                     } else if let error = error {
-                        if let bleError = error as? BLEManagerError {
-                            // Handle the BLEManagerError cases
-                            continuation.resume(throwing: bleError)
-                        } else {
-                            continuation.resume(throwing: error)
-                        }
+                        continuation.resume(throwing: error)
                     }
                     self.foundPeripheralCompletion = nil
                 }
@@ -265,12 +260,7 @@ class BLEManager: NSObject, CommProtocol {
                 if let _ = peripheral {
                     continuation.resume()
                 } else if let error = error {
-                    if let bleError = error as? BLEManagerError {
-                        // Handle the BLEManagerError cases
-                        continuation.resume(throwing: bleError)
-                    } else {
-                        continuation.resume(throwing: error)
-                    }
+                    continuation.resume(throwing: error)
                 }
             }
             connect(to: peripheral)
@@ -309,12 +299,7 @@ class BLEManager: NSObject, CommProtocol {
                     if let response = response {
                         continuation.resume(returning: response)
                     } else if let error = error {
-                        if let bleError = error as? BLEManagerError {
-                            // Handle the BLEManagerError cases
-                            continuation.resume(throwing: bleError)
-                        } else {
-                            continuation.resume(throwing: error)
-                        }
+                        continuation.resume(throwing: error)
                     }
                     self.sendMessageCompletion = nil
                 }

--- a/Sources/SwiftOBD2/Communication/bleManager.swift
+++ b/Sources/SwiftOBD2/Communication/bleManager.swift
@@ -144,7 +144,7 @@ class BLEManager: NSObject, CommProtocol {
                     } else if let error = error {
                         if let bleError = error as? BLEManagerError {
                             // Handle the BLEManagerError cases
-                            continuation.resume(returning: [bleError.description])
+                            continuation.resume(throwing: bleError)
                         } else {
                             continuation.resume(throwing: error)
                         }
@@ -267,7 +267,7 @@ class BLEManager: NSObject, CommProtocol {
                 } else if let error = error {
                     if let bleError = error as? BLEManagerError {
                         // Handle the BLEManagerError cases
-                        continuation.resume(returning: [bleError.description])
+                        continuation.resume(throwing: bleError)
                     } else {
                         continuation.resume(throwing: error)
                     }
@@ -311,7 +311,7 @@ class BLEManager: NSObject, CommProtocol {
                     } else if let error = error {
                         if let bleError = error as? BLEManagerError {
                             // Handle the BLEManagerError cases
-                            continuation.resume(returning: [bleError.description])
+                            continuation.resume(throwing: bleError)
                         } else {
                             continuation.resume(throwing: error)
                         }

--- a/Sources/SwiftOBD2/obd2service.swift
+++ b/Sources/SwiftOBD2/obd2service.swift
@@ -245,7 +245,7 @@ public struct MeasurementResult: Equatable {
     public let unit: Unit
 }
 
-enum OBDServiceError: Error {
+public enum OBDServiceError: Error {
     case noAdapterFound
     case notConnectedToVehicle
     case adapterConnectionFailed(underlyingError: Error)


### PR DESCRIPTION
Update sendMessageCompletion to handle other BLEManagerError case with human-readable message
- Return to original main barch code - using error
- CHANGE: Make "OBDServiceError" enum public, so Client can use it to extract human-readable message