### PR TITLE
Call correct Legacy Protocols for [1,2,4 & 5]

### DIFF
--- a/Sources/SwiftOBD2/Utils.swift
+++ b/Sources/SwiftOBD2/Utils.swift
@@ -173,11 +173,11 @@ protocol CANProtocol {
 
 // dictionary of all the protocols
 let protocols: [PROTOCOL: CANProtocol] = [
-    .protocol1: ISO_15765_4_11bit_500k(),
-    .protocol2: ISO_15765_4_29bit_500k(),
+    .protocol1: SAE_J1850_PWM(),
+    .protocol2: SAE_J1850_VPW(),
     .protocol3: ISO_9141_2(),
-    .protocol4: ISO_15765_4_29bit_250k(),
-    .protocol5: ISO_15765_4_11bit_500k(),
+    .protocol4: ISO_14230_4_KWP_5Baud(),
+    .protocol5: ISO_14230_4_KWP_Fast(),
     .protocol6: ISO_15765_4_11bit_500k(),
     .protocol7: ISO_15765_4_29bit_500k(),
     .protocol8: ISO_15765_4_11bit_250K(),

--- a/Sources/SwiftOBD2/codes.swift
+++ b/Sources/SwiftOBD2/codes.swift
@@ -13,7 +13,7 @@ public struct TroubleCode: Codable, Hashable, Comparable {
     }
 
     public let code: String
-    public let description: String
+    public var description: String
 }
 
 let codes: [String: String] = [


### PR DESCRIPTION
- Update Utlis: Use correct Legacy Protocols for [1,2,4 & 5]
- Make TroubleCode description editable: So codes with "No description available." can be updated in-app