### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,4 +1,6 @@
 name: Swift
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kkonteh97/SwiftOBD2/security/code-scanning/1](https://github.com/kkonteh97/SwiftOBD2/security/code-scanning/1)

To fix this problem, add a `permissions` block with explicit values at either the root level (before `jobs:`) or for individual jobs. Since none of the steps in this workflow (`checkout`, `build`, `test`) require write access, the minimum viable permissions are `contents: read`. This change should be made at the root level of the workflow YAML file, above the `jobs:` key, to cover all jobs unless more granular control is required. No other imports or library changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
