### PR TITLE
Add standing BLE reconnect and fix Swift 6 concurrency errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SwiftOBD2",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v12)
+        .iOS(.v16),
+        .macOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Sources/SwiftOBD2/Communication/BLE/AsyncSemaphore.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/AsyncSemaphore.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// A cancel-safe async semaphore for serializing access to a single-command BLE channel.
+///
+/// Uses `NSLock` to protect count and waiters array. Continuations are always
+/// resumed **outside** the lock to avoid deadlocks.
+final class AsyncSemaphore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count: Int
+    private var waiters: [(id: UUID, continuation: CheckedContinuation<Void, Never>)] = []
+
+    init(value: Int) {
+        precondition(value >= 0)
+        self.count = value
+    }
+
+    /// Wait to acquire a permit.
+    ///
+    /// - Returns: `true` if the permit was acquired, `false` if the task was cancelled
+    ///   before acquisition (waiter removed from queue without consuming a permit).
+    ///
+    /// Callers **must** only call `signal()` when this returns `true`.
+    func wait() async -> Bool {
+        // Fast path: try to decrement under lock without suspending
+        lock.lock()
+        if count > 0 {
+            count -= 1
+            lock.unlock()
+            return true
+        }
+        lock.unlock()
+
+        // Slow path: suspend until a permit is available or cancellation
+        let waiterId = UUID()
+        // Track whether the waiter was cancelled before acquisition.
+        // Uses a class box so the cancellation handler (Sendable closure) and
+        // the continuation body can share mutable state under the same lock.
+        let state = CancelState()
+
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                lock.lock()
+                // Re-check count — a signal may have arrived between the fast-path check and here
+                if count > 0 {
+                    count -= 1
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                // Check if task was already cancelled before we append.
+                // If onCancel fired first, it found nothing in the array and returned.
+                // Without this check the waiter would be queued with no cleanup path.
+                if Task.isCancelled {
+                    state.cancelledBeforeAcquire = true
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                waiters.append((id: waiterId, continuation: continuation))
+                lock.unlock()
+            }
+        } onCancel: {
+            // On cancel: remove waiter from queue if still there.
+            // Do NOT increment count — a queued waiter never consumed a permit.
+            lock.lock()
+            if let index = waiters.firstIndex(where: { $0.id == waiterId }) {
+                let removed = waiters.remove(at: index)
+                state.cancelledBeforeAcquire = true
+                lock.unlock()
+                // Resume the continuation so the suspended task can proceed.
+                removed.continuation.resume()
+            } else {
+                // Already dequeued by signal() — signal() will resume it normally.
+                // Permit was acquired via signal(), so cancelledBeforeAcquire stays false.
+                lock.unlock()
+            }
+        }
+
+        return !state.cancelledBeforeAcquire
+    }
+
+    /// Shared mutable flag between continuation body and cancellation handler.
+    private final class CancelState: @unchecked Sendable {
+        var cancelledBeforeAcquire = false
+    }
+
+    /// Release a permit. Resumes the next waiter if any, otherwise increments count.
+    func signal() {
+        lock.lock()
+        if let first = waiters.first {
+            waiters.removeFirst()
+            lock.unlock()
+            first.continuation.resume()
+        } else {
+            count += 1
+            lock.unlock()
+        }
+    }
+}

--- a/Sources/SwiftOBD2/Communication/BLE/AsyncSemaphore.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/AsyncSemaphore.swift
@@ -22,13 +22,16 @@ final class AsyncSemaphore: @unchecked Sendable {
     /// Callers **must** only call `signal()` when this returns `true`.
     func wait() async -> Bool {
         // Fast path: try to decrement under lock without suspending
-        lock.lock()
-        if count > 0 {
-            count -= 1
-            lock.unlock()
+        let acquiredWithoutSuspending = lock.withLock { () -> Bool in
+            if count > 0 {
+                count -= 1
+                return true
+            }
+            return false
+        }
+        if acquiredWithoutSuspending {
             return true
         }
-        lock.unlock()
 
         // Slow path: suspend until a permit is available or cancellation
         let waiterId = UUID()

--- a/Sources/SwiftOBD2/Communication/BLE/BLECharacteristicHandler.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLECharacteristicHandler.swift
@@ -96,7 +96,18 @@ class BLECharacteristicHandler {
         messageProcessor.processReceivedData(data)
     }
 
-    func reset() {
+    func reset(peripheral: CBPeripheral? = nil) {
+        // Unsubscribe from notifications before clearing references
+        // This prevents ghost notifications arriving after disconnect
+        if let peripheral = peripheral {
+            if let readChar = ecuReadCharacteristic, readChar.isNotifying {
+                peripheral.setNotifyValue(false, for: readChar)
+            }
+            if let writeChar = ecuWriteCharacteristic, writeChar != ecuReadCharacteristic, writeChar.isNotifying {
+                peripheral.setNotifyValue(false, for: writeChar)
+            }
+        }
+
         ecuReadCharacteristic = nil
         ecuWriteCharacteristic = nil
     }

--- a/Sources/SwiftOBD2/Communication/BLE/BLEConnection.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLEConnection.swift
@@ -93,7 +93,7 @@ class BLEConnection: NSObject, BLEConnectionProtocol {
             },
             operation: {
                 // Main connection task
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                try await withCheckedThrowingContinuation { [self] (continuation: CheckedContinuation<Void, Error>) in
                     var hasResumed = false
 
                     self.connectionCompletion = { [weak self] connectedPeripheral, error in

--- a/Sources/SwiftOBD2/Communication/BLE/BLEDataProcessor.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLEDataProcessor.swift
@@ -1,14 +1,178 @@
-import Combine
-import CoreBluetooth
 import Foundation
 import OSLog
 
-class BLEMessageProcessor {
-    private var buffer = Data()
-    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.example.app", category: "BLEMessageProcessor")
-    private var messageCompletion: (([String]?, Error?) -> Void)?
+// MARK: - Request Token & State Machine
 
+/// Opaque token returned by `beginRequest()` to scope all subsequent operations
+/// to the correct request generation.
+struct RequestToken {
+    let generation: Int
+}
+
+/// Internal state of a single pending BLE request.
+private enum RequestState {
+    case waitingForResponse
+    case earlyResult([String])
+    case earlyError(Error)
+    case suspended(CheckedContinuation<[String], Error>)
+    case completed
+}
+
+/// A single pending request slot (the sole source of truth for request lifecycle).
+private struct PendingRequest {
+    let generation: Int
+    var state: RequestState
+}
+
+// MARK: - BLEMessageProcessor
+
+class BLEMessageProcessor {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.example.app", category: "BLEMessageProcessor")
+
+    private let lock = NSLock()
+
+    // All mutable state is protected by `lock`
+    private var pendingRequest: PendingRequest?
+    private var currentGeneration: Int = 0
+    private var buffer = Data()
+
+    // MARK: - beginRequest
+
+    /// Create a new request slot. Any previous in-flight request is cancelled.
+    /// **Must** be called before writing the BLE command.
+    ///
+    /// Returns a `RequestToken` that must be passed to `awaitResponse(for:timeout:)`.
+    func beginRequest() -> RequestToken {
+        var staleContToResume: CheckedContinuation<[String], Error>?
+
+        lock.lock()
+        // Cancel previous request if it has a suspended continuation
+        if let prev = pendingRequest {
+            if case .suspended(let cont) = prev.state {
+                staleContToResume = cont
+            }
+        }
+        currentGeneration += 1
+        buffer.removeAll()
+        pendingRequest = PendingRequest(generation: currentGeneration, state: .waitingForResponse)
+        let token = RequestToken(generation: currentGeneration)
+        lock.unlock()
+
+        // Resume stale continuation outside lock
+        if let cont = staleContToResume {
+            cont.resume(throwing: BLEManagerError.sendingMessagesInProgress)
+        }
+
+        return token
+    }
+
+    // MARK: - awaitResponse
+
+    /// Wait for the BLE response associated with `token`.
+    ///
+    /// - If BLE data already arrived (early result), returns immediately.
+    /// - Otherwise suspends until `processReceivedData` delivers the result or timeout fires.
+    func awaitResponse(for token: RequestToken, timeout: TimeInterval) async throws -> [String] {
+        try Task.checkCancellation()
+
+        // Check for early result / validate token
+        lock.lock()
+        guard let req = pendingRequest, req.generation == token.generation else {
+            lock.unlock()
+            throw BLEMessageProcessorError.staleRequestToken
+        }
+
+        switch req.state {
+        case .earlyResult(let lines):
+            pendingRequest?.state = .completed
+            lock.unlock()
+            return lines
+
+        case .earlyError(let error):
+            pendingRequest?.state = .completed
+            lock.unlock()
+            throw error
+
+        case .waitingForResponse:
+            // Will suspend below
+            lock.unlock()
+
+        default:
+            lock.unlock()
+            throw BLEMessageProcessorError.staleRequestToken
+        }
+
+        // Suspend: wrap in timeout + cancellation handler
+        return try await withTimeout(
+            seconds: timeout,
+            timeoutError: BLEMessageProcessorError.responseTimeout,
+            onTimeout: { [weak self] in
+                guard let self else { return }
+                self.lock.lock()
+                guard let req = self.pendingRequest,
+                      req.generation == token.generation,
+                      case .suspended(let cont) = req.state else {
+                    self.lock.unlock()
+                    return
+                }
+                self.pendingRequest?.state = .completed
+                self.buffer.removeAll()
+                self.lock.unlock()
+                cont.resume(throwing: BLEMessageProcessorError.responseTimeout)
+            }
+        ) { [self] in
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String], Error>) in
+                    lock.lock()
+                    // Re-validate: generation must still match and state must still be waitingForResponse
+                    guard let req = pendingRequest,
+                          req.generation == token.generation else {
+                        lock.unlock()
+                        continuation.resume(throwing: BLEMessageProcessorError.staleRequestToken)
+                        return
+                    }
+
+                    switch req.state {
+                    case .waitingForResponse:
+                        pendingRequest?.state = .suspended(continuation)
+                        lock.unlock()
+
+                    case .earlyResult(let lines):
+                        // Data arrived between the initial check and here
+                        pendingRequest?.state = .completed
+                        lock.unlock()
+                        continuation.resume(returning: lines)
+
+                    case .earlyError(let error):
+                        pendingRequest?.state = .completed
+                        lock.unlock()
+                        continuation.resume(throwing: error)
+
+                    default:
+                        lock.unlock()
+                        continuation.resume(throwing: BLEMessageProcessorError.staleRequestToken)
+                    }
+                }
+            } onCancel: {
+                lock.lock()
+                guard let req = pendingRequest,
+                      req.generation == token.generation,
+                      case .suspended(let cont) = req.state else {
+                    lock.unlock()
+                    return
+                }
+                pendingRequest?.state = .completed
+                lock.unlock()
+                cont.resume(throwing: CancellationError())
+            }
+        }
+    }
+
+    // MARK: - processReceivedData
+
+    /// Called from the BLE callback queue when data arrives from the adapter.
     func processReceivedData(_ data: Data) {
+        lock.lock()
         buffer.append(data)
 
         guard let string = String(data: buffer, encoding: .utf8) else {
@@ -17,21 +181,81 @@ class BLEMessageProcessor {
                 logger.warning("Buffer exceeded max size, clearing")
                 buffer.removeAll()
             }
+            lock.unlock()
             return
         }
 
-        // Check for end of response marker
-        if string.contains(">") {
-            let response = parseResponse(from: string)
-            handleParsedResponse(response)
-            buffer.removeAll()
+        // Check for end-of-response marker
+        guard string.contains(">") else {
+            lock.unlock()
+            return
+        }
+
+        // Parse response and clear buffer
+        let lines = parseResponse(from: string)
+        buffer.removeAll()
+
+        // Determine what to do with the result
+        guard let req = pendingRequest else {
+            lock.unlock()
+            logger.warning("Received response with no pending request (nil slot)")
+            return
+        }
+
+        let isNoData = lines.isEmpty || (lines.first?.uppercased().contains("NO DATA") == true)
+
+        switch req.state {
+        case .suspended(let continuation):
+            pendingRequest?.state = .completed
+            lock.unlock()
+            if isNoData {
+                continuation.resume(throwing: BLEManagerError.noData)
+            } else {
+                continuation.resume(returning: lines)
+            }
+
+        case .waitingForResponse:
+            // BLE response arrived before awaitResponse was called — store as early result
+            if isNoData {
+                pendingRequest?.state = .earlyError(BLEManagerError.noData)
+            } else {
+                pendingRequest?.state = .earlyResult(lines)
+            }
+            lock.unlock()
+
+        case .completed, .earlyResult, .earlyError:
+            lock.unlock()
+            logger.warning("Received response but slot already resolved (state: completed/early)")
+
         }
     }
 
+    // MARK: - reset
+
+    /// Full reset — called on disconnect. Bumps generation to invalidate all
+    /// outstanding tokens, cancels any suspended continuation.
+    func reset() {
+        var contToResume: CheckedContinuation<[String], Error>?
+
+        lock.lock()
+        if let req = pendingRequest, case .suspended(let cont) = req.state {
+            contToResume = cont
+        }
+        currentGeneration += 1
+        pendingRequest = nil
+        buffer.removeAll()
+        lock.unlock()
+
+        if let cont = contToResume {
+            cont.resume(throwing: BLEManagerError.peripheralNotConnected)
+        }
+    }
+
+    // MARK: - Private Helpers
+
     private func parseResponse(from string: String) -> [String] {
-        // Split by newlines and clean up
         let lines = string
-            .replacingOccurrences(of: ">", with: "") // Remove prompt marker
+            .replacingOccurrences(of: ">", with: "")
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
@@ -39,65 +263,16 @@ class BLEMessageProcessor {
         logger.debug("Parsed response: \(lines)")
         return lines
     }
-
-    private func handleParsedResponse(_ lines: [String]) {
-       let completion = messageCompletion
-       messageCompletion = nil
-
-       guard let completion = completion else {
-           logger.warning("Received response with no pending completion")
-           return
-       }
-
-       if let firstLine = lines.first, firstLine.uppercased().contains("NO DATA") {
-           completion(nil, BLEManagerError.noData)
-       } else if lines.isEmpty {
-           completion(nil, BLEManagerError.noData)
-       } else {
-           completion(lines, nil)
-       }
-   }
-
-
-    func waitForResponse(timeout: TimeInterval) async throws -> [String] {
-            try await withTimeout(seconds: timeout, timeoutError: BLEMessageProcessorError.responseTimeout) { [self] in
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String], Error>) in
-
-                    // Check if there's already a pending command
-                    assert(messageCompletion == nil, "Concurrent command detected")
-
-
-                    messageCompletion = { response, error in
-                        if let response = response {
-                            continuation.resume(returning: response)
-                        } else if let error = error {
-                            continuation.resume(throwing: error)
-                        } else {
-                            continuation.resume(throwing: BLEMessageProcessorError.responseTimeout)
-                        }
-                    }
-
-                }
-            }
-        }
-
-    func reset() {
-           buffer.removeAll()
-           let completion = messageCompletion
-           messageCompletion = nil
-
-           // Call completion with error if it exists
-           completion?(nil, BLEManagerError.peripheralNotConnected)
-       }
 }
 
 // MARK: - Error Types
 
-enum BLEMessageProcessorError: Error, LocalizedError {
+enum BLEMessageProcessorError: Error, Equatable, LocalizedError {
     case characteristicNotWritable
     case writeOperationFailed
     case responseTimeout
     case invalidResponseData
+    case staleRequestToken
 
     var errorDescription: String? {
         switch self {
@@ -109,6 +284,8 @@ enum BLEMessageProcessorError: Error, LocalizedError {
             return "Timeout waiting for BLE response"
         case .invalidResponseData:
             return "Received invalid response data from BLE device"
+        case .staleRequestToken:
+            return "Request token is stale (generation mismatch)"
         }
     }
 }

--- a/Sources/SwiftOBD2/Communication/BLE/BLEDataProcessor.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLEDataProcessor.swift
@@ -75,31 +75,33 @@ class BLEMessageProcessor {
     func awaitResponse(for token: RequestToken, timeout: TimeInterval) async throws -> [String] {
         try Task.checkCancellation()
 
-        // Check for early result / validate token
-        lock.lock()
-        guard let req = pendingRequest, req.generation == token.generation else {
-            lock.unlock()
-            throw BLEMessageProcessorError.staleRequestToken
+        // Check for early result / validate token.
+        // Returns the early lines, throws on early error / stale token, or
+        // returns nil when the request is still pending and we must suspend.
+        let earlyLines: [String]? = try lock.withLock {
+            guard let req = pendingRequest, req.generation == token.generation else {
+                throw BLEMessageProcessorError.staleRequestToken
+            }
+
+            switch req.state {
+            case .earlyResult(let lines):
+                pendingRequest?.state = .completed
+                return lines
+
+            case .earlyError(let error):
+                pendingRequest?.state = .completed
+                throw error
+
+            case .waitingForResponse:
+                // Will suspend below
+                return nil
+
+            default:
+                throw BLEMessageProcessorError.staleRequestToken
+            }
         }
-
-        switch req.state {
-        case .earlyResult(let lines):
-            pendingRequest?.state = .completed
-            lock.unlock()
-            return lines
-
-        case .earlyError(let error):
-            pendingRequest?.state = .completed
-            lock.unlock()
-            throw error
-
-        case .waitingForResponse:
-            // Will suspend below
-            lock.unlock()
-
-        default:
-            lock.unlock()
-            throw BLEMessageProcessorError.staleRequestToken
+        if let earlyLines {
+            return earlyLines
         }
 
         // Suspend: wrap in timeout + cancellation handler

--- a/Sources/SwiftOBD2/Communication/BLE/BLEPeripheralManager.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLEPeripheralManager.swift
@@ -47,12 +47,12 @@ class BLEPeripheralManager: NSObject, ObservableObject {
         hasResumedConnection = true
     }
 
-    func setPeripheral(_ peripheral: CBPeripheral?) {
+    func setPeripheral(_ peripheral: CBPeripheral?, discoverServices: Bool = true) {
         connectedPeripheral?.delegate = nil
         connectedPeripheral = peripheral
         connectedPeripheral?.delegate = self
 
-        if let peripheral = peripheral {
+        if discoverServices, let peripheral = peripheral, peripheral.state == .connected {
             peripheral.discoverServices(BLEPeripheralScanner.supportedServices)
         }
     }

--- a/Sources/SwiftOBD2/Communication/BLE/BLEScanner.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/BLEScanner.swift
@@ -87,7 +87,7 @@ class BLEPeripheralScanner: ObservableObject {
             completion?(nil, BLEScannerError.scanTimeout)
             self.hasResumedPeripheral = true
         }) {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CBPeripheral, Error>) in
+            try await withCheckedThrowingContinuation { [self] (continuation: CheckedContinuation<CBPeripheral, Error>) in
                 self.foundPeripheralCompletion = { [weak self] peripheral, error in
                     // Validate this callback is for the current scan generation
                     guard let self = self else { return }

--- a/Sources/SwiftOBD2/Communication/BLE/bleManager.swift
+++ b/Sources/SwiftOBD2/Communication/BLE/bleManager.swift
@@ -76,6 +76,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     private var reconnectAttempts: Int = 0
     private let maxReconnectAttempts: Int = 5
     private var reconnectTask: Task<Void, Never>?
+    private var connectTimeoutTask: Task<Void, Never>?
 
     // Focused components
     private var centralManager: CBCentralManager!
@@ -92,6 +93,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     deinit {
         // Clean up resources
         reconnectTask?.cancel()
+        connectTimeoutTask?.cancel()
         cancellables.removeAll()
         disconnectPeripheral()
         obdDebug("BLEManager deinitialized", category: .bluetooth)
@@ -143,6 +145,11 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
 
     func disconnectPeripheral() {
         guard let peripheral = peripheralManager.connectedPeripheral else { return }
+        guard centralManager.state == .poweredOn else {
+            obdWarning("Skipping disconnect request while Bluetooth is not powered on", category: .bluetooth)
+            resetAllState()
+            return
+        }
         centralManager.cancelPeripheralConnection(peripheral)
     }
 
@@ -172,21 +179,31 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     }
 
     func centralManagerDidPowerOn() {
-        // Already connected peripheral — reconnect
         if let device = peripheralManager.connectedPeripheral {
-            connect(to: device)
+            switch device.state {
+            case .connecting:
+                obdInfo("Power on: restored peripheral is already connecting, waiting for callback", category: .bluetooth)
+                scheduleConnectTimeout(for: device)
+            case .connected:
+                obdInfo("Power on: restored peripheral is already connected", category: .bluetooth)
+                cancelConnectTimeout()
+            case .disconnecting:
+                obdInfo("Power on: restored peripheral is disconnecting, waiting for cleanup", category: .bluetooth)
+            case .disconnected:
+                obdInfo("Power on: cleared stale restored peripheral reference", category: .bluetooth)
+                cancelConnectTimeout()
+                peripheralManager.reset()
+                connectionState = .disconnected
+            @unknown default:
+                obdWarning("Power on: restored peripheral in unknown state, clearing", category: .bluetooth)
+                cancelConnectTimeout()
+                peripheralManager.reset()
+                connectionState = .disconnected
+            }
             return
         }
 
-        // Auto-reconnect to last known peripheral if enabled
-        if autoReconnectEnabled, let uuid = lastConnectedPeripheralUUID,
-           let peripheral = centralManager.retrievePeripherals(withIdentifiers: [uuid]).first {
-            obdInfo("Power on: auto-reconnecting to last peripheral", category: .bluetooth)
-            connect(to: peripheral)
-            return
-        }
-
-        startScanning(BLEPeripheralScanner.supportedServices)
+        obdDebug("Bluetooth powered on; waiting for reconnect orchestration", category: .bluetooth)
     }
 
     func didDiscover(_: CBCentralManager, peripheral: CBPeripheral, advertisementData: [String: Any], rssi: NSNumber) {
@@ -195,8 +212,16 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     }
 
     func connect(to peripheral: CBPeripheral) {
+        guard centralManager.state == .poweredOn else {
+            obdWarning("Ignoring connect request while Bluetooth is not powered on", category: .bluetooth)
+            return
+        }
+
         let peripheralName = peripheral.name ?? "Unnamed"
         obdInfo("Attempting connection to peripheral: \(peripheralName)", category: .bluetooth)
+
+        lastConnectedPeripheralUUID = peripheral.identifier
+        peripheralManager.setPeripheral(peripheral, discoverServices: false)
         
         let oldState = connectionState
         connectionState = .connecting
@@ -207,6 +232,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
         }
         
         centralManager.connect(peripheral, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+        scheduleConnectTimeout(for: peripheral)
         if centralManager.isScanning {
             centralManager.stopScan()
         }
@@ -214,9 +240,10 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
 
     func didConnect(_: CBCentralManager, peripheral: CBPeripheral) {
         obdInfo("Connected to peripheral: \(peripheral.name ?? "Unnamed")", category: .bluetooth)
+        cancelConnectTimeout()
         reconnectAttempts = 0 // Reset on successful connection
         lastConnectedPeripheralUUID = peripheral.identifier
-        peripheralManager.setPeripheral(peripheral)
+        peripheralManager.setPeripheral(peripheral, discoverServices: true)
         // Note: connectionState will be set to .connectedToAdapter in peripheralManager delegate
     }
 
@@ -224,6 +251,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
         let peripheralName = peripheral.name ?? "Unnamed"
         let errorMsg = error?.localizedDescription ?? "Unknown error"
         obdError("Connection failed to peripheral: \(peripheralName) - \(errorMsg)", category: .bluetooth)
+        cancelConnectTimeout()
         
         let oldState = connectionState
         connectionState = .error
@@ -237,6 +265,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     func didDisconnect(_: CBCentralManager, peripheral: CBPeripheral, error: Error?) {
         let peripheralName = peripheral.name ?? "Unnamed"
         let wasUnexpected = error != nil
+        cancelConnectTimeout()
 
         if wasUnexpected {
             obdWarning("Unexpected disconnection from \(peripheralName): \(error!.localizedDescription)", category: .bluetooth)
@@ -258,25 +287,75 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
             obdInfo("Scheduling auto-reconnect attempt \(reconnectAttempts + 1)/\(maxReconnectAttempts)", category: .bluetooth)
             scheduleAutoReconnect(peripheralUUID: peripheralUUID)
         } else if reconnectAttempts >= maxReconnectAttempts {
-            obdWarning("Max reconnect attempts reached, giving up", category: .bluetooth)
+            obdWarning("Max reconnect attempts reached, falling back to standing reconnect", category: .bluetooth)
             reconnectAttempts = 0
+            armStandingReconnect()
         }
+    }
+
+    /// Leave an OS-level pending connection to the saved adapter, with no
+    /// app-side timeout. CoreBluetooth keeps the request alive while the app
+    /// is suspended or terminated (via state restoration) and completes it
+    /// whenever the adapter powers on — typically at the next ignition. This
+    /// is what allows trips to start without the user opening the app.
+    ///
+    /// Only call this when the adapter is unreachable. Arming after a
+    /// disconnect from a reachable-but-misbehaving adapter would create an
+    /// instant connect/fail loop.
+    @discardableResult
+    func armStandingReconnect() -> Bool {
+        guard autoReconnectEnabled else { return false }
+        guard centralManager.state == .poweredOn else {
+            obdDebug("Standing reconnect not armed: Bluetooth is not powered on", category: .bluetooth)
+            return false
+        }
+        guard let uuid = lastConnectedPeripheralUUID,
+              let peripheral = centralManager.retrievePeripherals(withIdentifiers: [uuid]).first else {
+            obdDebug("Standing reconnect not armed: no saved peripheral in system cache", category: .bluetooth)
+            return false
+        }
+
+        switch peripheral.state {
+        case .connected, .connecting:
+            // Already connected or a connect is already pending at the OS level.
+            return true
+        default:
+            break
+        }
+
+        obdInfo("Arming standing reconnect to \(peripheral.name ?? uuid.uuidString) — pending connect with no timeout", category: .bluetooth)
+        peripheralManager.setPeripheral(peripheral, discoverServices: false)
+        // Deliberately no scheduleConnectTimeout and no .connecting state:
+        // the request waits silently at the OS level until the adapter appears.
+        centralManager.connect(peripheral, options: [CBConnectPeripheralOptionNotifyOnDisconnectionKey: true])
+        return true
     }
 
     func willRestoreState(_: CBCentralManager, dict: [String: Any]) {
         if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral],
            let peripheral = peripherals.first {
             obdDebug("Restoring peripheral: \(peripheral.name ?? "Unnamed"), state: \(peripheral.state.rawValue)", category: .bluetooth)
+            lastConnectedPeripheralUUID = peripheral.identifier
 
             // Check peripheral state before restoring
             if peripheral.state == .connected {
                 // Peripheral still connected - set up properly
-                peripheralManager.setPeripheral(peripheral)
+                peripheralManager.setPeripheral(peripheral, discoverServices: true)
                 connectionState = .connectedToAdapter
+                cancelConnectTimeout()
                 obdInfo("Restored connected peripheral", category: .bluetooth)
+            } else if peripheral.state == .connecting {
+                // A pending connect survived app termination (standing
+                // reconnect). Leave it pending with no timeout — iOS completes
+                // it when the adapter powers on. State stays .disconnected so
+                // the app treats the standing request as invisible.
+                peripheralManager.setPeripheral(peripheral, discoverServices: false)
+                connectionState = .disconnected
+                obdInfo("Restored pending peripheral connection — leaving it standing", category: .bluetooth)
             } else {
                 // Peripheral not connected - clear stale reference
                 obdWarning("Restored peripheral not connected, clearing state", category: .bluetooth)
+                cancelConnectTimeout()
                 peripheralManager.reset()
                 connectionState = .disconnected
             }
@@ -472,14 +551,17 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
                 obdInfo("Auto-reconnect disabled during wait, aborting", category: .bluetooth)
                 return
             }
+            guard self.centralManager.state == .poweredOn else {
+                obdInfo("Auto-reconnect skipped because Bluetooth is not powered on", category: .bluetooth)
+                return
+            }
 
             // Try to retrieve peripheral from iOS cache
             if let peripheral = self.centralManager.retrievePeripherals(withIdentifiers: [peripheralUUID]).first {
                 obdInfo("Auto-reconnect: found peripheral in cache, connecting...", category: .bluetooth)
                 self.connect(to: peripheral)
             } else {
-                obdWarning("Auto-reconnect: peripheral not in cache, starting scan...", category: .bluetooth)
-                self.startScanning(BLEPeripheralScanner.supportedServices)
+                obdWarning("Auto-reconnect: peripheral not in cache, skipping generic scan", category: .bluetooth)
             }
         }
     }
@@ -489,6 +571,7 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     /// Complete reset of all BLE state for reconnection
     /// Call this AFTER disconnection is confirmed
     public func resetAllState() {
+        cancelConnectTimeout()
         let oldState = connectionState
 
         // Reset characteristic handler with notification unsubscription
@@ -522,6 +605,43 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
         obdInfo("BLE state fully reset", category: .bluetooth)
     }
 
+    private func cancelConnectTimeout() {
+        connectTimeoutTask?.cancel()
+        connectTimeoutTask = nil
+    }
+
+    private func scheduleConnectTimeout(for peripheral: CBPeripheral) {
+        cancelConnectTimeout()
+
+        let timeout = BLEConstants.connectionTimeout + 2.0
+        let targetIdentifier = peripheral.identifier
+
+        connectTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard let self, !Task.isCancelled else { return }
+
+            guard self.connectionState == .connecting,
+                  self.peripheralManager.connectedPeripheral?.identifier == targetIdentifier else {
+                return
+            }
+
+            obdWarning("Connect attempt timed out for peripheral \(peripheral.name ?? peripheral.identifier.uuidString), forcing cleanup", category: .bluetooth)
+
+            if self.centralManager.state == .poweredOn {
+                self.centralManager.cancelPeripheralConnection(peripheral)
+            } else {
+                obdWarning("Bluetooth not powered on while timing out connect attempt", category: .bluetooth)
+            }
+
+            self.resetAllState()
+
+            // The adapter is unreachable (engine off, out of range). Replace
+            // the cancelled attempt with a standing pending connect so the
+            // next ignition reconnects without any app-side wake signal.
+            self.armStandingReconnect()
+        }
+    }
+
     /// Disconnect and wait for completion
     /// - Parameter timeout: Maximum time to wait for disconnect
     /// - Returns: True if disconnect confirmed, false if timed out
@@ -529,6 +649,11 @@ class BLEManager: NSObject, CommProtocol, BLEPeripheralManagerDelegate {
     func disconnectPeripheralAsync(timeout: TimeInterval = 3.0) async -> Bool {
         guard let peripheral = peripheralManager.connectedPeripheral else {
             return true // Already disconnected
+        }
+        guard centralManager.state == .poweredOn else {
+            obdWarning("Disconnect requested while Bluetooth is not powered on, forcing cleanup", category: .bluetooth)
+            resetAllState()
+            return false
         }
 
         centralManager.cancelPeripheralConnection(peripheral)

--- a/Sources/SwiftOBD2/Communication/mockManager.swift
+++ b/Sources/SwiftOBD2/Communication/mockManager.swift
@@ -57,7 +57,7 @@ class MOCKComm: CommProtocol {
             mode = mode + 40
 
             if response.count > 18 {
-                var chunks = response.chunked(by: 15)
+                let chunks = response.chunked(by: 15)
 
                 var ff = chunks[0]
 

--- a/Sources/SwiftOBD2/Communication/wifiManager.swift
+++ b/Sources/SwiftOBD2/Communication/wifiManager.swift
@@ -5,6 +5,7 @@
 //  Created by kemo konteh on 2/26/24.
 //
 
+import Combine
 import CoreBluetooth
 import Foundation
 import Network
@@ -17,6 +18,40 @@ protocol CommProtocol {
     func scanForPeripherals() async throws
     var connectionStatePublisher: Published<ConnectionState>.Publisher { get }
     var obdDelegate: OBDServiceDelegate? { get set }
+
+    // MARK: - Peripheral Scanning (BLE-specific, no-op for WiFi/Mock)
+    func startPeripheralScanning()
+    func stopPeripheralScanning()
+    var discoveredPeripheralPublisher: AnyPublisher<CBPeripheral, Never> { get }
+
+    // MARK: - Bluetooth State
+    var bluetoothState: CBManagerState { get }
+
+    // MARK: - Peripheral Retrieval
+    func retrievePeripheral(uuid: UUID) -> CBPeripheral?
+
+    // MARK: - Auto-Reconnect
+    var autoReconnectEnabled: Bool { get set }
+    var lastConnectedPeripheralUUID: UUID? { get set }
+}
+
+// Default no-op implementations for non-BLE managers
+extension CommProtocol {
+    func startPeripheralScanning() {}
+    func stopPeripheralScanning() {}
+    var discoveredPeripheralPublisher: AnyPublisher<CBPeripheral, Never> {
+        Empty<CBPeripheral, Never>().eraseToAnyPublisher()
+    }
+    var bluetoothState: CBManagerState { .unknown }
+    func retrievePeripheral(uuid: UUID) -> CBPeripheral? { nil }
+    var autoReconnectEnabled: Bool {
+        get { false }
+        set { }
+    }
+    var lastConnectedPeripheralUUID: UUID? {
+        get { nil }
+        set { }
+    }
 }
 
 enum CommunicationError: Error {

--- a/Sources/SwiftOBD2/Communication/wifiManager.swift
+++ b/Sources/SwiftOBD2/Communication/wifiManager.swift
@@ -33,6 +33,11 @@ protocol CommProtocol {
     // MARK: - Auto-Reconnect
     var autoReconnectEnabled: Bool { get set }
     var lastConnectedPeripheralUUID: UUID? { get set }
+
+    /// Leave an OS-level pending connection to the saved adapter (BLE only).
+    /// Returns true if a connection is now pending or already established.
+    @discardableResult
+    func armStandingReconnect() -> Bool
 }
 
 // Default no-op implementations for non-BLE managers
@@ -52,6 +57,8 @@ extension CommProtocol {
         get { nil }
         set { }
     }
+    @discardableResult
+    func armStandingReconnect() -> Bool { false }
 }
 
 enum CommunicationError: Error {

--- a/Sources/SwiftOBD2/elm327.swift
+++ b/Sources/SwiftOBD2/elm327.swift
@@ -90,7 +90,7 @@ class ELM327 {
             .sink { [weak self] state in
                 self?.connectionState = state
                 self?.obdDelegate?.connectionStateChanged(state: state)
-                self?.logger.debug("Connection state updated: \(state.hashValue)")
+                self?.logger.debug("Connection state updated: \(state.description)")
             }
             .store(in: &cancellables)
     }

--- a/Sources/SwiftOBD2/obd2service.swift
+++ b/Sources/SwiftOBD2/obd2service.swift
@@ -236,6 +236,15 @@ public class OBDService: ObservableObject, OBDServiceDelegate {
         set { elm327.commManager.lastConnectedPeripheralUUID = newValue }
     }
 
+    /// Leave an OS-level pending BLE connection to the saved adapter, with no
+    /// app-side timeout. iOS completes it whenever the adapter powers on,
+    /// relaunching the app via CoreBluetooth state restoration if needed.
+    /// Requires `autoReconnectEnabled` and a saved peripheral UUID.
+    @discardableResult
+    public func armStandingReconnect() -> Bool {
+        elm327.commManager.armStandingReconnect()
+    }
+
     // MARK: - Reinitialize Connection (skip BLE connect, run ELM327 init only)
 
     /// Reinitialize ELM327 after BLE auto-reconnect.


### PR DESCRIPTION
## What changed

**Standing reconnect (the auto-start fix).** When the saved adapter becomes unreachable — connect timeout fires or the auto-reconnect retry budget is exhausted — `BLEManager` now leaves an OS-level pending `connect()` with no app-side timeout instead of giving up. CoreBluetooth keeps that request alive while the app is suspended or terminated, and completes it via state restoration the moment the adapter powers on (typically next ignition). `willRestoreState` now preserves a restored pending connect instead of scheduling a kill-timer on it, and keeps the connection state `.disconnected` so the standing request is invisible to app logic. New `armStandingReconnect()` is exposed through `CommProtocol` (no-op for WiFi/Mock) and `OBDService`.

Arming only happens when the adapter is **unreachable** — never after a disconnect from a reachable adapter — so a misbehaving adapter cannot cause a connect/fail loop.

**Swift 6 concurrency fixes.** `NSLock.lock()/unlock()` are `noasync` in Swift 6; the call sites directly inside async bodies (`AsyncSemaphore.wait()` fast path, `BLEMessageProcessor.awaitResponse` early-check) now use scoped `NSLock.withLock`. Package platforms bumped to iOS 16 / macOS 13 to allow the Foundation API (the consuming app targets iOS 18.4). Explicit `[self]` captures resolve the weak-capture ownership warnings in `BLEConnection`/`BLEScanner`, plus a `var`→`let` in mockManager.

## Why

ChatOBD trips were silently missed whenever the app was terminated between drives: after engine-off the adapter disconnects, ~30s of retries fail, and nothing was left pending — so the next drive only recorded if a location wake happened to win a BLE scan race. The standing connect removes that race entirely.

## Reviewer notes

- Lock/unlock pairing and resume-outside-lock discipline in the refactored sections are unchanged; `swift test` passes 26/26.
- BLE behavior needs real-device validation (simulator can't exercise pending connects / state restoration).
- Companion app PR: Maxymvs/ChatOBD-xAI (arming hooks on backgrounding and after failed background-wake reconnects).